### PR TITLE
resolved wrong signature when send GET plus params

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -142,7 +142,7 @@ class API
 
         } else {
 
-            $oauth = $this->getSignature($method, $url);
+            $oauth = $this->getSignature($method, $url, $params);
             $headers = [];
             $headers[] = 'Content-type: application/json';
             $headers[] = $this->buildAutheaders($oauth);


### PR DESCRIPTION
I was recieving Error 401 from the API. Happened only when I was trying to send and get parameter like `user.fields`.
So I thought it may was a wrong signature and found out the missing parameter.

